### PR TITLE
missing RemoveAnn from import in __ini__

### DIFF
--- a/gatenlp/pam/pampac/__init__.py
+++ b/gatenlp/pam/pampac/__init__.py
@@ -9,7 +9,7 @@ from gatenlp.pam.pampac.pampac_parsers import PampacParser, All, And, Ann, AnnAt
 from gatenlp.pam.pampac.pampac_parsers import Function, N, Or, Seq, Text
 from gatenlp.pam.pampac.pampac import Pampac, PampacAnnotator
 from gatenlp.pam.pampac.rule import Rule
-from gatenlp.pam.pampac.actions import AddAnn, Actions, UpdateAnnFeatures
+from gatenlp.pam.pampac.actions import AddAnn, Actions, UpdateAnnFeatures,RemoveAnn
 from gatenlp.pam.pampac.actions import Getter
 from gatenlp.pam.pampac.getters import GetAnn, GetEnd, GetType, GetText, GetStart
 from gatenlp.pam.pampac.getters import GetFeature, GetFeatures, GetRegexGroup


### PR DESCRIPTION
pam.pampac __ini__ file is missing RemoveAnn action in the list of elements to import. 
This causes a problem when trying to use the function 